### PR TITLE
Create maliput ros node

### DIFF
--- a/maliput_ros/CMakeLists.txt
+++ b/maliput_ros/CMakeLists.txt
@@ -13,6 +13,10 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
 find_package(maliput REQUIRED)
+find_package(maliput_ros_interfaces REQUIRED)
+find_package(maliput_ros_translation REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 ##############################################################################
@@ -66,8 +70,25 @@ endif()
 # Export
 ##############################################################################
 
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
 ament_environment_hooks(setup.sh.in)
 ament_export_dependencies(ament_cmake)
+ament_export_dependencies(maliput)
+ament_export_dependencies(maliput_ros_interfaces)
+ament_export_dependencies(maliput_ros_translation)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(rclcpp_lifecycle)
 ament_export_dependencies(yaml-cpp)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_package()

--- a/maliput_ros/include/maliput_ros/ros/maliput_query.h
+++ b/maliput_ros/include/maliput_ros/ros/maliput_query.h
@@ -1,0 +1,61 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <maliput/api/road_geometry.h>
+#include <maliput/api/road_network.h>
+#include <maliput/common/maliput_throw.h>
+
+namespace maliput_ros {
+namespace ros {
+
+/// @brief Proxy to a maliput::api::RoadNetwork to make queries to it.
+class MaliputQuery final {
+ public:
+  /// @brief Constructs a MaliputQuery.
+  /// @param[in] road_network The maliput::api::RoadNetwork to hold. It must not be nullptr.
+  /// @throws maliput::common::assertion_error When @p road_network is nullptr.
+  explicit MaliputQuery(std::unique_ptr<maliput::api::RoadNetwork> road_network)
+      : road_network_(std::move(road_network)) {
+    MALIPUT_THROW_UNLESS(road_network_ != nullptr);
+  }
+
+  /// @return The maliput::api::RoadGeometry.
+  inline const maliput::api::RoadGeometry* road_geometry() const { return road_network_->road_geometry(); }
+
+ private:
+  std::unique_ptr<maliput::api::RoadNetwork> road_network_{};
+};
+
+}  // namespace ros
+}  // namespace maliput_ros

--- a/maliput_ros/include/maliput_ros/ros/maliput_query_node.h
+++ b/maliput_ros/include/maliput_ros/ros/maliput_query_node.h
@@ -1,0 +1,151 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <maliput_ros_interfaces/srv/road_geometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+#include "maliput_ros/ros/maliput_query.h"
+
+namespace maliput_ros {
+namespace ros {
+
+/// MaliputQueryNode is a LifecycleNode that serves as proxy to a maliput::api::RoadNetwork
+/// set of queries.
+///
+/// It defines the following parameters:
+/// - yaml_configuration_path: a string which contains the path to a YAML file. The YAML is parsed
+///   with maliput_ros::utils::LoadYamlConfigFile() to obtain a maliput_ros::utils::MaliputRoadNetworkConfiguration
+///   and then use it to create a maliput::api::RoadNetwork from it.
+///
+/// The following depicts what this node does on each state transtion:
+/// - MaliputQueryNode::on_configure(): the maliput::api::RoadNetwork, the MaliputQuery and the services are created.
+/// - MaliputQueryNode::on_activate(): the services are enabled to respond to queries.
+/// - MaliputQueryNode::on_deactivate(): the services are disabled to respond to queries.
+/// - MaliputQueryNode::on_cleanup(): the maliput::api::RoadNetwork, the MaliputQuery, and the services are torn down.
+///
+/// This query server offers:
+/// - /road_geometry: responds the maliput::api::RoadGeometry configuration.
+class MaliputQueryNode final : public rclcpp_lifecycle::LifecycleNode {
+ public:
+  using LifecyleNodeCallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  /// Create a new MaliputQueryNode node with the specified name.
+  ///
+  /// Forwards a call: MaliputQueryNode(node_name, "", options) to signal empty namespace.
+  /// @param[in] node_name Name of the node.
+  /// @param[in] options Additional options to control creation of the node.
+  MaliputQueryNode(const std::string& node_name, const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
+      : MaliputQueryNode(node_name, "", options) {}
+
+  /// Create a node based on the node name and a rclcpp::Context.
+  ///
+  /// @param[in] node_name Name of the node.
+  /// @param[in] namespace_ Namespace of the node.
+  /// @param[in] options Additional options to control creation of the node.
+  MaliputQueryNode(const std::string& node_name, const std::string& namespace_,
+                   const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+
+ private:
+  static constexpr const char* kRoadGeometryServiceName = "road_geometry";
+  static constexpr const char* kYamlConfigurationPath = "yaml_configuration_path";
+  static constexpr const char* kYamlConfigurationPathDescription =
+      "File path to the yaml file containing the maliput plugin RoadNework loader.";
+
+  // @return The path to the YAMl file containing the maliput plugin configuration from the node parameter.
+  std::string GetMaliputYamlFilePath() const;
+
+  // @brief Responds the maliput::api::RoadGeometry configuration.
+  // @pre The node must be in the ACTIVE state.
+  // @param[in] request Unused.
+  // @param[out] response Loads the maliput::api::RoadGeometry description.
+  void RoadGeometryCallback(const std::shared_ptr<maliput_ros_interfaces::srv::RoadGeometry::Request> request,
+                            std::shared_ptr<maliput_ros_interfaces::srv::RoadGeometry::Response> response) const;
+
+  // @brief Loads the maliput::api::RoadNetwork from the yaml_configuration_path contents.
+  // @return true When the load procedure is successful.
+  bool LoadMaliputQuery();
+
+  // @brief Deletes the maliput::api::RoadNetwork and the MaliputQuery.
+  void TearDownMaliputQuery();
+
+  // @brief Creates all services of this node.
+  // @return true
+  bool InitializeAllServices();
+
+  // @brief Creates all services of this node.
+  // @return true
+  void TearDownAllServices();
+
+  // @brief Loads the maliput_query_ and the services.
+  // @param[in] state Unused.
+  // @return LifecyleNodeCallbackReturn::SUCCESS When the load procedure is successful.
+  // Otherwise, LifecyleNodeCallbackReturn::FAILURE.
+  LifecyleNodeCallbackReturn on_configure(const rclcpp_lifecycle::State& state) override;
+
+  // @brief Enables queries to all services.
+  // @param[in] state Unused.
+  // @return LifecyleNodeCallbackReturn::SUCCESS.
+  LifecyleNodeCallbackReturn on_activate(const rclcpp_lifecycle::State& state) override;
+
+  // @brief Disables queries to all services.
+  // @param[in] state Unused.
+  // @return LifecyleNodeCallbackReturn::SUCCESS.
+  LifecyleNodeCallbackReturn on_deactivate(const rclcpp_lifecycle::State& state) override;
+
+  // @brief Deletes all services and deletes maliput_query_.
+  // @param[in] state Unused.
+  // @return LifecyleNodeCallbackReturn::SUCCESS.
+  LifecyleNodeCallbackReturn on_cleanup(const rclcpp_lifecycle::State& state) override;
+
+  // @brief No-op.
+  // @param[in] state Unused.
+  // @return LifecyleNodeCallbackReturn::SUCCESS.
+  LifecyleNodeCallbackReturn on_shutdown(const rclcpp_lifecycle::State& state) override {
+    RCLCPP_INFO(get_logger(), "on_shutdown");
+    return LifecyleNodeCallbackReturn::SUCCESS;
+  }
+
+  // Works as a barrier to all service callbacks. When it is true, callbacks can operate.
+  std::atomic<bool> is_active_;
+  // /road_geometry service.
+  rclcpp::Service<maliput_ros_interfaces::srv::RoadGeometry>::SharedPtr road_geometry_srv_;
+  // Proxy to a maliput::api::RoadNetwork queries.
+  std::unique_ptr<maliput_ros::ros::MaliputQuery> maliput_query_;
+};
+
+}  // namespace ros
+}  // namespace maliput_ros

--- a/maliput_ros/launch/maliput_ros.launch.py
+++ b/maliput_ros/launch/maliput_ros.launch.py
@@ -1,0 +1,90 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Woven Planet.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import launch
+import launch_ros
+import lifecycle_msgs
+
+def generate_launch_description():
+    # YAML configuration path to load the maliput plugin configuration.
+    maliput_yaml_path = launch.substitutions.LaunchConfiguration('maliput_yaml_path')
+
+    # YAML configuration path argument, to let the user configure it.
+    # The 'maliput_yaml_path' variable will hold this value.
+    maliput_yaml_path_arg = launch.actions.DeclareLaunchArgument(
+        'maliput_yaml_path',
+        default_value='',
+        description='Path to the YAML file containing the maliput plugin configuration.')
+    
+    # The query server node.
+    maliput_query_server_node = launch_ros.actions.LifecycleNode(
+        package='maliput_ros', executable='maliput_ros', name='query_server', output='screen',
+        parameters=[{"yaml_configuration_path": maliput_yaml_path}])
+    
+    # When the query_server reaches the 'inactive' state, make it take the 'activate' transition.
+    register_event_handler_for_query_server_reaches_inactive_state = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=maliput_query_server_node, goal_state='inactive',
+            entities=[
+                launch.actions.LogInfo(
+                    msg="node 'query_server' reached the 'inactive' state, 'activating'."),
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(maliput_query_server_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
+                )),
+            ],
+        )
+    )
+
+    # When the query_server node reaches the 'active' state, log a message.
+    register_event_handler_for_query_server_reaches_active_state = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=maliput_query_server_node, goal_state='active',
+            entities=[
+                launch.actions.LogInfo(
+                    msg="node 'query_server' reached the 'active' state, launching 'listener'."),
+            ],
+        )
+    )
+
+    # Make the talker node take the 'configure' transition.
+    emit_event_to_request_that_query_server_does_configure_transition = launch.actions.EmitEvent(
+        event=launch_ros.events.lifecycle.ChangeState(
+            lifecycle_node_matcher=launch.events.matches_action(maliput_query_server_node),
+            transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+        )
+    )
+
+    return launch.LaunchDescription([
+        maliput_yaml_path_arg,
+        register_event_handler_for_query_server_reaches_inactive_state,
+        register_event_handler_for_query_server_reaches_active_state,
+        maliput_query_server_node,
+        emit_event_to_request_that_query_server_does_configure_transition,
+    ])

--- a/maliput_ros/package.xml
+++ b/maliput_ros/package.xml
@@ -11,8 +11,17 @@
 
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
+
   <depend>maliput</depend>
+  <depend>maliput_ros_interfaces</depend>
+  <depend>maliput_ros_translation</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>yaml-cpp</depend>
+
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/maliput_ros/resources/maliput_malidrive_plugin.yml
+++ b/maliput_ros/resources/maliput_malidrive_plugin.yml
@@ -1,0 +1,17 @@
+# Example configuration for maliput_malidrive and to load the TShapeRoad.xodr map.
+# TODO: fix the path to the node.
+maliput:
+  backend: "maliput_malidrive"
+  parameters:
+    road_geometry_id: "t_shape_road"
+    opendrive_file: "/home/agalbachicar/maliput_ws_focal/install/maliput_malidrive/share/maliput_malidrive/resources/odr/TShapeRoad.xodr"
+    linear_tolerance: "0.001"
+    max_linear_tolerance: "0.01"
+    angular_tolerance: "0.001"
+    scale_length: "1.0"
+    inertial_to_backend_frame_translation: "{0, 0, 0}"
+    build_policy: "sequential"
+    num_threads: "1"
+    simplification_policy: "none"
+    standard_strictness_policy: "strict"
+    omit_nondrivable_lanes: "true"

--- a/maliput_ros/src/maliput_ros/CMakeLists.txt
+++ b/maliput_ros/src/maliput_ros/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(ros)
 add_subdirectory(utils)

--- a/maliput_ros/src/maliput_ros/ros/CMakeLists.txt
+++ b/maliput_ros/src/maliput_ros/ros/CMakeLists.txt
@@ -1,0 +1,71 @@
+##############################################################################
+# Sources
+##############################################################################
+
+add_library(maliput_ros_node
+  maliput_query_node.cc
+)
+
+add_library(maliput_ros::maliput_ros_node ALIAS maliput_ros_node)
+
+set_target_properties(maliput_ros_node
+  PROPERTIES
+    OUTPUT_NAME maliput_ros_node
+)
+
+target_include_directories(maliput_ros_node
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(maliput_ros_node
+  maliput
+  maliput_ros_interfaces
+  maliput_ros_translation
+  rclcpp
+  rclcpp_lifecycle
+)
+
+target_link_libraries(maliput_ros_node
+  maliput_ros::utils
+)
+
+add_executable(maliput_ros
+  maliput_query_server.cc
+)
+
+target_include_directories(maliput_ros
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(maliput_ros
+  rclcpp
+  rclcpp_lifecycle
+)
+
+target_link_libraries(maliput_ros
+  maliput_ros::maliput_ros_node
+)
+
+##############################################################################
+# Export
+##############################################################################
+
+install(
+  TARGETS maliput_ros_node
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+install(
+  TARGETS maliput_ros
+  EXPORT ${PROJECT_NAME}-targets
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/maliput_ros/src/maliput_ros/ros/maliput_query_node.cc
+++ b/maliput_ros/src/maliput_ros/ros/maliput_query_node.cc
@@ -1,0 +1,133 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_ros/ros/maliput_query_node.h"
+
+#include <functional>
+#include <stdexcept>
+
+#include <maliput/api/road_network.h>
+#include <maliput/common/maliput_throw.h>
+#include <maliput/plugin/create_road_network.h>
+#include <maliput_ros_translation/convert.h>
+
+#include "maliput_ros/utils/yaml_parser.h"
+
+namespace maliput_ros {
+namespace ros {
+
+MaliputQueryNode::MaliputQueryNode(const std::string& node_name, const std::string& namespace_,
+                                   const rclcpp::NodeOptions& options)
+    : rclcpp_lifecycle::LifecycleNode(node_name, namespace_, options), is_active_(false) {
+  RCLCPP_INFO(get_logger(), "MaliputQueryNode");
+  // Initialize the parameter for the YAML file path configuration.
+  rcl_interfaces::msg::ParameterDescriptor maliput_plugin_yaml_file_path_descriptor;
+  maliput_plugin_yaml_file_path_descriptor.name = kYamlConfigurationPath;
+  maliput_plugin_yaml_file_path_descriptor.description = kYamlConfigurationPathDescription;
+  maliput_plugin_yaml_file_path_descriptor.read_only = true;
+  this->declare_parameter(maliput_plugin_yaml_file_path_descriptor.name, rclcpp::ParameterValue(std::string{}),
+                          maliput_plugin_yaml_file_path_descriptor);
+}
+
+void MaliputQueryNode::RoadGeometryCallback(
+    const std::shared_ptr<maliput_ros_interfaces::srv::RoadGeometry::Request>,
+    std::shared_ptr<maliput_ros_interfaces::srv::RoadGeometry::Response> response) const {
+  RCLCPP_INFO(get_logger(), "RoadGeometryCallback");
+  if (!is_active_.load()) {
+    RCLCPP_WARN(get_logger(), "The node is not active yet.");
+    return;
+  }
+  response->road_geometry = maliput_ros_translation::ToRosMessage(maliput_query_->road_geometry());
+}
+
+std::string MaliputQueryNode::GetMaliputYamlFilePath() const {
+  return this->get_parameter(kYamlConfigurationPath).get_parameter_value().get<std::string>();
+}
+
+bool MaliputQueryNode::LoadMaliputQuery() {
+  RCLCPP_INFO(get_logger(), "LoadMaliputQuery");
+  RCLCPP_INFO(get_logger(), "File path: " + GetMaliputYamlFilePath());
+  try {
+    const maliput_ros::utils::MaliputRoadNetworkConfiguration configurations =
+        maliput_ros::utils::LoadYamlConfigFile(GetMaliputYamlFilePath());
+    std::unique_ptr<maliput::api::RoadNetwork> road_network =
+        maliput::plugin::CreateRoadNetwork(configurations.backend_name, configurations.backend_parameters);
+    maliput_query_ = std::make_unique<MaliputQuery>(std::move(road_network));
+  } catch (std::runtime_error& e) {
+    RCLCPP_ERROR(get_logger(), std::string{"Error loading maliput RoadNetwork: "} + e.what());
+    return false;
+  }
+  return true;
+}
+
+void MaliputQueryNode::TearDownMaliputQuery() {
+  RCLCPP_INFO(get_logger(), "TearDownMaliputQuery");
+  maliput_query_.reset();
+}
+
+bool MaliputQueryNode::InitializeAllServices() {
+  RCLCPP_INFO(get_logger(), "InitializeAllServices");
+  road_geometry_srv_ = this->create_service<maliput_ros_interfaces::srv::RoadGeometry>(
+      kRoadGeometryServiceName,
+      std::bind(&MaliputQueryNode::RoadGeometryCallback, this, std::placeholders::_1, std::placeholders::_2));
+  return true;
+}
+
+void MaliputQueryNode::TearDownAllServices() {
+  RCLCPP_INFO(get_logger(), "TearDownAllServices");
+  road_geometry_srv_.reset();
+}
+
+MaliputQueryNode::LifecyleNodeCallbackReturn MaliputQueryNode::on_activate(const rclcpp_lifecycle::State&) {
+  RCLCPP_INFO(get_logger(), "on_activate");
+  is_active_.store(true);
+  return LifecyleNodeCallbackReturn::SUCCESS;
+}
+
+MaliputQueryNode::LifecyleNodeCallbackReturn MaliputQueryNode::on_deactivate(const rclcpp_lifecycle::State&) {
+  RCLCPP_INFO(get_logger(), "on_deactivate");
+  is_active_.store(false);
+  return LifecyleNodeCallbackReturn::SUCCESS;
+}
+
+MaliputQueryNode::LifecyleNodeCallbackReturn MaliputQueryNode::on_configure(const rclcpp_lifecycle::State&) {
+  RCLCPP_INFO(get_logger(), "on_configure");
+  const bool configure_result = LoadMaliputQuery() && InitializeAllServices();
+  return configure_result ? LifecyleNodeCallbackReturn::SUCCESS : LifecyleNodeCallbackReturn::FAILURE;
+}
+
+MaliputQueryNode::LifecyleNodeCallbackReturn MaliputQueryNode::on_cleanup(const rclcpp_lifecycle::State&) {
+  RCLCPP_INFO(get_logger(), "on_cleanup");
+  TearDownAllServices();
+  TearDownMaliputQuery();
+  return LifecyleNodeCallbackReturn::SUCCESS;
+}
+
+}  // namespace ros
+}  // namespace maliput_ros

--- a/maliput_ros/src/maliput_ros/ros/maliput_query_server.cc
+++ b/maliput_ros/src/maliput_ros/ros/maliput_query_server.cc
@@ -1,0 +1,67 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "maliput_ros/ros/maliput_query_node.h"
+
+namespace maliput_ros {
+namespace ros {
+namespace node {
+namespace {
+
+static constexpr const char* kNodeName = "maliput_query_server";
+
+// force flush of the stdout buffer.
+// this ensures a correct sync of all prints
+// even when executed simultaneously within the launch file.
+void ForceStdoutFlush() { setvbuf(stdout, NULL, _IONBF, BUFSIZ); }
+
+}  // namespace
+
+int Main(int argc, char* argv[]) {
+  ForceStdoutFlush();
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  auto node = std::make_shared<MaliputQueryNode>(kNodeName);
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+  rclcpp::shutdown();
+  return 0;
+}
+
+}  // namespace node
+}  // namespace ros
+}  // namespace maliput_ros
+
+int main(int argc, char* argv[]) { return maliput_ros::ros::node::Main(argc, argv); }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://maliput.readthedocs.io/en/latest/contributing.html
-->
# 🎉 New feature

Part of #1

## Summary

Creates a node and provides a launchfile to execute it. The node only responds to the `/road_geometry` service call at the moment and lacks of testing, it will be implemented in a subsequent PR.

Also, there is no explicit `exec_depend` on maliput_malidrive as there is actually no dependency with this example resource file (note it is not installed on purpose). We still need to define what to do with it.

## Test it

Unit tests, and you can try launching it from the terminal:

```sh
$ colcon build --packages-up-to maliput_malidrive maliput_ros --event-handlers console_direct+
[...]
$ source install/setup.bash
$ ros2 launch maliput_ros maliput_ros.launch.py maliput_yaml_path:="/home/agalbachicar/maliput_ws_focal/src/ros2_maliput/maliput_ros/resources/maliput_malidrive_plugin.yml"
[INFO] [launch]: All log files can be found below /home/agalbachicar/.ros/log/2023-01-02-09-37-52-750746-5a83e2746402-54415
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [maliput_ros-1]: process started with pid [54427]
[maliput_ros-1] [INFO] [1672652272.908667953] [query_server]: MaliputQueryNode
[maliput_ros-1] [INFO] [1672652273.137092467] [query_server]: on_configure
[maliput_ros-1] [INFO] [1672652273.137155825] [query_server]: LoadMaliputQuery
[maliput_ros-1] [INFO] [1672652273.137179680] [query_server]: File path: /home/agalbachicar/maliput_ws_focal/src/ros2_maliput/maliput_ros/resources/maliput_malidrive_plugin.yml
[maliput_ros-1] [INFO] Plugin Id: maliput_malidrive was correctly loaded.
[maliput_ros-1] [INFO] Number of plugins loaded: 1
[maliput_ros-1] [INFO] RoadGeometry loaded successfully after iteration [0] using:
[maliput_ros-1]         |__ linear_tolerance = 0.001
[maliput_ros-1]         |__ angular_tolerance = 0.001
[maliput_ros-1]         |__ scale_length = 1
[maliput_ros-1] [INFO] [1672652273.230751628] [query_server]: InitializeAllServices
[INFO] [launch.user]: node 'query_server' reached the 'inactive' state, 'activating'.
[maliput_ros-1] [INFO] [1672652273.233952199] [query_server]: on_activate
[INFO] [launch.user]: node 'query_server' reached the 'active' state, launching 'listener'.
```

From another terminal, you can try:

```sh
$ ros2 service call /road_geometry maliput_ros_interfaces/srv/RoadGeometry {}[3/1801]
>                                                                                                                                
waiting for service to become available...                                                                                       
requester: making request: maliput_ros_interfaces.srv.RoadGeometry_Request()                                                     

response:
maliput_ros_interfaces.srv.RoadGeometry_Response(road_geometry=maliput_ros_interfaces.msg.RoadGeometry(id=maliput_ros_interfaces.msg.RoadGeometryId(id='t_shape_road'), junction_ids=[maliput_ros_interfaces.msg.JunctionId(id='0_0'), maliput_ros_interfaces.msg.JunctionId(id='1_0'), maliput_ros_interfaces.msg.JunctionId(id='2_0'), maliput_ros_interfaces.msg.JunctionId(id='3')], branch_point_ids=[maliput_ros_interfaces.msg.BranchPointId(id='1'), maliput_ros_interfaces.msg.BranchPointId(id='2'), maliput_ros_interfaces.msg.BranchPointId(id='3'), maliput_ros_interfaces.msg.BranchPointId(id='4'), maliput_ros_interfaces.msg.BranchPointId(id='5'), maliput_ros_interfaces.msg.BranchPointId(id='6'), maliput_ros_interfaces.msg.BranchPointId(id='7'), maliput_ros_interfaces.msg.BranchPointId(id='8'), maliput_ros_interfaces.msg.BranchPointId(id='9'), maliput_ros_interfaces.msg.BranchPointId(id='10'), maliput_ros_interfaces.msg.BranchPointId(id='11'), maliput_ros_interfaces.msg.BranchPointId(id='12')], linear_tolerance=0.001, angular_t
olerance=0.001, scale_length=1.0, inertial_to_backend_frame_translation=geometry_msgs.msg.Vector3(x=0.0, y=0.0, z=0.0)))
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
