### PR TITLE
Removes tests to avoid breaking CI with generated files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       image: ubuntu:20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.4
     - uses: ros-tooling/action-ros-ci@v0.2
       id: action_ros_ci_step
       with:

--- a/maliput_ros_interfaces/CMakeLists.txt
+++ b/maliput_ros_interfaces/CMakeLists.txt
@@ -22,8 +22,6 @@ find_package(rosidl_default_generators REQUIRED)
 
 message(STATUS "\n\n========= Project Configuration ========\n")
 
-set(BUILD_SHARED_LIBS true)
-
 ##############################################################################
 # Sources
 ##############################################################################
@@ -55,7 +53,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${MESSAGES}
   ${SERVICE_MSGS}
   DEPENDENCIES builtin_interfaces geometry_msgs
-  ADD_LINTER_TESTS
+  # TODO(#12): restore ament_lint_auto_find_test_dependencies() once pep257 test is solved in CI.
+  # ADD_LINTER_TESTS
 )
 
 ##############################################################################


### PR DESCRIPTION
# 🦟 Bug fix

Part of  #12

## Summary

- Removes extra tests over the generated files.
- Removes a build warning for shared libraries.
- Updates the setup-ros version in CI.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
